### PR TITLE
Fix wp user query warning on wordpress 4.3 has_published_posts

### DIFF
--- a/side-user.php
+++ b/side-user.php
@@ -83,7 +83,8 @@ class P2P_Side_User extends P2P_Side {
 			'number' => '',
 			'count_total' => true,
 			'fields' => 'all',
-			'who' => ''
+			'who' => '',
+			'has_published_posts' => null,
 		) );
 
 		$uq->prepare_query();


### PR DESCRIPTION
As per wordpress 4.3 new query param in users is added `has_published_posts` [ticket](https://core.trac.wordpress.org/ticket/32250)

Which throws notice while getting posts to user connection. 

``` php
PHP Notice:  Undefined index: has_published_posts in /htdocs/wp-includes/user.php on line 662
```

This patch fixes that warning. 
