### PR TITLE
Exception: Be more specific about $ptype in Can't find $ptype

### DIFF
--- a/side-post.php
+++ b/side-post.php
@@ -22,7 +22,7 @@ class P2P_Side_Post extends P2P_Side {
 		$ptype_object = get_post_type_object( $ptype );
 
 		if ( !$ptype_object ) {
-			throw new P2P_Exception( "Can't find $ptype." );
+			throw new P2P_Exception( "Can't find post type $ptype." );
 		}
 
 		return $ptype_object;


### PR DESCRIPTION
Exception: Avoid confusing by telling the user that the post type $ptype is not found instead of just telling that $ptype is not found.
