### PR TITLE
Add filter for "other query" arguments

### DIFF
--- a/query.php
+++ b/query.php
@@ -130,7 +130,7 @@ class P2P_Query {
 			'p2p:per_page' => -1
 		) );
 		
-		$qv = apply_filters( 'p2p_other_query_args', $qv );
+		$qv = apply_filters( 'p2p_other_query_args', $qv, $directed, $which );
 
 		if ( 'any' != $this->items )
 			$qv['p2p:include'] = _p2p_normalize( $this->items );

--- a/query.php
+++ b/query.php
@@ -129,6 +129,8 @@ class P2P_Query {
 			'fields' => 'ids',
 			'p2p:per_page' => -1
 		) );
+		
+		$qv = apply_filters( 'p2p_other_query_args', $qv );
 
 		if ( 'any' != $this->items )
 			$qv['p2p:include'] = _p2p_normalize( $this->items );


### PR DESCRIPTION
I have to identify queries made by the do_other_query method of the P2P_Query class. Because original query parameters are not passed to the "other query", I would need a filter for query arguments.

I would be nice, if you could add this filter to the WordPress.org version of the plugin too.
