### PR TITLE
Fixes bug if there are duplicate posts in items array

### DIFF
--- a/api.php
+++ b/api.php
@@ -313,13 +313,19 @@ function p2p_distribute_connected( $items, $connected, $prop_name ) {
 
 	foreach ( $items as $item ) {
 		$item->$prop_name = array();
-		$indexed_list[ $item->ID ] = $item;
+		if ( ! isset( $indexed_list[ $item->ID ] ) ) {
+			$indexed_list[ $item->ID ] = [];
+		}
+		$indexed_list[ $item->ID ][] = $item;
 	}
 
 	$groups = scb_list_group_by( $connected, '_p2p_get_other_id' );
 
 	foreach ( $groups as $outer_item_id => $connected_items ) {
-		$indexed_list[ $outer_item_id ]->$prop_name = $connected_items;
+		foreach ( $indexed_list[ $outer_item_id ] as $item ) {
+			$item->$prop_name = $connected_items;
+		}
+		
 	}
 }
 


### PR DESCRIPTION
Hi,

If i try to connect posts from array which contains same post multiple time, only the first post is connected.

Exemple : 

```
$posts = [
object(WP_Post) { 
 ['ID'] => 1,
 [...]
},
object(WP_Post) { 
 ['ID'] => 1,
 [...]
}
]
p2p_type( 'movies_to_actors' )->each_connected( $posts, array(), 'actors' );

var_dump($posts)  => [
object(WP_Post) { 
 ['ID'] => 1,
 ['actors'] => [...]
 [...]
},
object(WP_Post) { 
 ['ID'] => 1,
 [...]
}
]
```
The second post should have an actors attribute.

This pull request fixes this bug.


