### PR TITLE
PHP 8.2: Allow dynamic property

### DIFF
--- a/connection-type.php
+++ b/connection-type.php
@@ -1,6 +1,6 @@
 <?php
 
-class P2P_Connection_Type {
+#[AllowDynamicProperties] class P2P_Connection_Type {
 
 	public $side;
 

--- a/side-post.php
+++ b/side-post.php
@@ -1,6 +1,6 @@
 <?php
 
-class P2P_Side_Post extends P2P_Side {
+#[AllowDynamicProperties] class P2P_Side_Post extends P2P_Side {
 
 	protected $item_type = 'P2P_Item_Post';
 


### PR DESCRIPTION
For users with PHP 8.2 this allows them to have error reporting on and also use PHP8.2
Without these 2 allow-rules the code could throw visible notices